### PR TITLE
Extra code to properly set empty instruments to air blocks instead of completly ignoring it.

### DIFF
--- a/nbs_generate_schematic.py
+++ b/nbs_generate_schematic.py
@@ -200,7 +200,6 @@ def main():
         schem.setBlock((offset, 0, -1), "minecraft:air")
         schem.setBlock((offset + 1, 0, -1), "minecraft:air")
         schem.setBlock((offset, 0, 0), "minecraft:air")
-        schem.setBlock((offset + 1, 0, 0), "minecraft:air")
       
       if upperOctaveEmpty == 0:
         upperChest1 = createChest('right', upperChest1)
@@ -212,7 +211,6 @@ def main():
         schem.setBlock((offset, 1, -1), "minecraft:air")
         schem.setBlock((offset + 1, 1, -1), "minecraft:air")
         schem.setBlock((offset, 1, 0), "minecraft:air")
-        schem.setBlock((offset + 1, 1, 0), "minecraft:air")
       
       currentModule += 1
       offset += 2

--- a/nbs_generate_schematic.py
+++ b/nbs_generate_schematic.py
@@ -144,6 +144,7 @@ def main():
       currentIndices[instrument][octave] += 1
   
   minimalChestContents = removeEmptyChests(allChestContents)
+
   # turn minimalChestContents into a schematic
   schem = mcschematic.MCSchematic()
   offset = 0
@@ -195,22 +196,12 @@ def main():
         schem.setBlock((offset, 0, -1), lowerChest1)
         schem.setBlock((offset + 1, 0, -1), lowerChest2)
         schem.setBlock((offset, 0, 0), createSign(instrument, currentModule, 0))
-      else:
-        schem.setBlock((offset, 0, -1), "minecraft:air")
-        schem.setBlock((offset + 1, 0, -1), "minecraft:air")
-        schem.setBlock((offset, 0, 0), "minecraft:air")
-        schem.setBlock((offset + 1, 0, 0), "minecraft:air")
       if upperOctaveEmpty == 0:
         upperChest1 = createChest('right', upperChest1)
         upperChest2 = createChest('left', upperChest2)
         schem.setBlock((offset, 1, -1), upperChest1)
         schem.setBlock((offset + 1, 1, -1), upperChest2)
         schem.setBlock((offset, 1, 0), createSign(instrument, currentModule, 1))
-      else:
-        schem.setBlock((offset, 1, -1), "minecraft:air")
-        schem.setBlock((offset + 1, 1, -1), "minecraft:air")
-        schem.setBlock((offset, 1, 0), "minecraft:air")
-        schem.setBlock((offset + 1, 1, 0), "minecraft:air")
       
       currentModule += 1
       offset += 2

--- a/nbs_generate_schematic.py
+++ b/nbs_generate_schematic.py
@@ -144,7 +144,6 @@ def main():
       currentIndices[instrument][octave] += 1
   
   minimalChestContents = removeEmptyChests(allChestContents)
-
   # turn minimalChestContents into a schematic
   schem = mcschematic.MCSchematic()
   offset = 0
@@ -196,12 +195,22 @@ def main():
         schem.setBlock((offset, 0, -1), lowerChest1)
         schem.setBlock((offset + 1, 0, -1), lowerChest2)
         schem.setBlock((offset, 0, 0), createSign(instrument, currentModule, 0))
+      else:
+        schem.setBlock((offset, 0, -1), "minecraft:air")
+        schem.setBlock((offset + 1, 0, -1), "minecraft:air")
+        schem.setBlock((offset, 0, 0), "minecraft:air")
+        schem.setBlock((offset + 1, 0, 0), "minecraft:air")
       if upperOctaveEmpty == 0:
         upperChest1 = createChest('right', upperChest1)
         upperChest2 = createChest('left', upperChest2)
         schem.setBlock((offset, 1, -1), upperChest1)
         schem.setBlock((offset + 1, 1, -1), upperChest2)
         schem.setBlock((offset, 1, 0), createSign(instrument, currentModule, 1))
+      else:
+        schem.setBlock((offset, 1, -1), "minecraft:air")
+        schem.setBlock((offset + 1, 1, -1), "minecraft:air")
+        schem.setBlock((offset, 1, 0), "minecraft:air")
+        schem.setBlock((offset + 1, 1, 0), "minecraft:air")
       
       currentModule += 1
       offset += 2

--- a/nbs_generate_schematic.py
+++ b/nbs_generate_schematic.py
@@ -196,12 +196,23 @@ def main():
         schem.setBlock((offset, 0, -1), lowerChest1)
         schem.setBlock((offset + 1, 0, -1), lowerChest2)
         schem.setBlock((offset, 0, 0), createSign(instrument, currentModule, 0))
+      else:
+        schem.setBlock((offset, 0, -1), "minecraft:air")
+        schem.setBlock((offset + 1, 0, -1), "minecraft:air")
+        schem.setBlock((offset, 0, 0), "minecraft:air")
+        schem.setBlock((offset + 1, 0, 0), "minecraft:air")
+      
       if upperOctaveEmpty == 0:
         upperChest1 = createChest('right', upperChest1)
         upperChest2 = createChest('left', upperChest2)
         schem.setBlock((offset, 1, -1), upperChest1)
         schem.setBlock((offset + 1, 1, -1), upperChest2)
         schem.setBlock((offset, 1, 0), createSign(instrument, currentModule, 1))
+      else:
+        schem.setBlock((offset, 1, -1), "minecraft:air")
+        schem.setBlock((offset + 1, 1, -1), "minecraft:air")
+        schem.setBlock((offset, 1, 0), "minecraft:air")
+        schem.setBlock((offset + 1, 1, 0), "minecraft:air")
       
       currentModule += 1
       offset += 2


### PR DESCRIPTION
With the current code, new schematics will not overwrite past instruments in a song if it is not used in the new song.
1. Load Perry The Platypus Theme Schematic into the world. 
![2023-09-04_01 58 19](https://github.com/jazziiRed/nbs-converter/assets/64191125/9f2560af-b5d3-43be-bde4-fbc08c4b1a3b)

2. Try to load Tetris A Theme with the current code. 
![2023-09-04_01 58 56](https://github.com/jazziiRed/nbs-converter/assets/64191125/781ce03a-449a-45f4-aa07-05340dd732c9)
As you can see, the schematic outline doesn't go past bass drum, essentially leaving the snare drum section and onwards untouched with the Perry the Platypus theme intact, which accidentally mixes the 2 songs together.

3. Load Tetris A Theme with the modified code.
![2023-09-04_01 59 22](https://github.com/jazziiRed/nbs-converter/assets/64191125/439b912a-a47d-4b2c-96c8-7c9bfb8845f7)
The schematic outline now properly extends all the way to the end, erasing all traces of the Perry the Platypus Theme from the Tetris A Theme.

Schematics used: 
[schems.zip](https://github.com/jazziiRed/nbs-converter/files/12506788/schems.zip)


Tested on Litematica and WorldEdit.